### PR TITLE
プレゼンテーション操作領域の確保とキャンバス描画制限を実装

### DIFF
--- a/frontend/src/components/PresentationScreen.css
+++ b/frontend/src/components/PresentationScreen.css
@@ -6,6 +6,20 @@
   overflow: hidden;
 }
 
+/* 下部5%のプレゼンテーション操作領域を示す */
+.presentation-container::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 5%;
+  pointer-events: none;
+  border-top: 2px dashed rgba(255, 255, 255, 0.2);
+  background: rgba(0, 0, 0, 0.1);
+  z-index: 5;
+}
+
 .presentation-container.fullscreen {
   position: fixed;
   top: 0;
@@ -29,6 +43,19 @@
   cursor: crosshair;
   pointer-events: all;
   z-index: 10;
+}
+
+/* 下部5%の領域ではポインターイベントを無効化 */
+.drawing-canvas::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 5%;
+  pointer-events: none;
+  border-top: 2px dashed rgba(255, 255, 255, 0.3);
+  box-sizing: border-box;
 }
 
 .control-panel {

--- a/frontend/src/components/PresentationScreen.tsx
+++ b/frontend/src/components/PresentationScreen.tsx
@@ -104,6 +104,13 @@ const PresentationScreen: React.FC<PresentationScreenProps> = ({
     const x = event.clientX - rect.left;
     const y = event.clientY - rect.top;
 
+    // 下部5%の領域では描画を開始しない
+    const canvasHeight = canvas.height;
+    const drawableHeight = canvasHeight * 0.95;
+    if (y > drawableHeight) {
+      return;
+    }
+
     setIsDrawing(true);
     setStartPosition({ x, y });
   };
@@ -116,7 +123,12 @@ const PresentationScreen: React.FC<PresentationScreenProps> = ({
 
     const rect = canvas.getBoundingClientRect();
     const currentX = event.clientX - rect.left;
-    const currentY = event.clientY - rect.top;
+    let currentY = event.clientY - rect.top;
+
+    // 下部5%の領域に描画されないように制限
+    const canvasHeight = canvas.height;
+    const drawableHeight = canvasHeight * 0.95;
+    currentY = Math.min(currentY, drawableHeight);
 
     // 現在の四角を一時的に表示
     const ctx = canvas.getContext('2d');
@@ -151,7 +163,12 @@ const PresentationScreen: React.FC<PresentationScreenProps> = ({
 
     const rect = canvas.getBoundingClientRect();
     const endX = event.clientX - rect.left;
-    const endY = event.clientY - rect.top;
+    let endY = event.clientY - rect.top;
+
+    // 下部5%の領域に描画されないように制限
+    const canvasHeight = canvas.height;
+    const drawableHeight = canvasHeight * 0.95;
+    endY = Math.min(endY, drawableHeight);
 
     const newRectangle: Rectangle = {
       x: Math.min(startPosition.x, endX),
@@ -159,6 +176,11 @@ const PresentationScreen: React.FC<PresentationScreenProps> = ({
       width: Math.abs(endX - startPosition.x),
       height: Math.abs(endY - startPosition.y)
     };
+
+    // 下部5%領域に侵入しないよう最終調整
+    if (newRectangle.y + newRectangle.height > drawableHeight) {
+      newRectangle.height = drawableHeight - newRectangle.y;
+    }
 
     // 最小サイズの四角のみ追加
     if (newRectangle.width > 10 && newRectangle.height > 10) {
@@ -225,6 +247,11 @@ const PresentationScreen: React.FC<PresentationScreenProps> = ({
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
+        style={{ 
+          pointerEvents: 'all',
+          // 下部5%領域でのクリックを無効化するためのclip-pathを使用
+          clipPath: 'polygon(0 0, 100% 0, 100% 95%, 0 95%)'
+        }}
       />
 
       {/* コントロールパネル */}


### PR DESCRIPTION
✨ プレゼンテーション操作領域の確保

プレゼンテーションレイヤーはそのままで、描画キャンバスでの四角描画時に下部5%の領域には描画されないよう制限を実装しました。

## 主要変更点
- `handleMouseDown`: 下部5%領域でのクリック開始を無効化
- `handleMouseMove`: 描画中のY座標を上部95%に制限
- `handleMouseUp`: 最終的な四角のY座標とサイズを上部95%に制限
- `clip-path`により下部5%のクリックを完全に無効化
- 視覚的境界線でプレゼンテーション操作領域を明示

## 効果
- プレゼンテーション用iframeはフルサイズ（100%）で表示
- 描画キャンバスは上部95%の領域にのみ制限
- 下部5%のスペースがプレゼンテーション操作用として確保される

Closes #9

Generated with [Claude Code](https://claude.ai/code)