### PR TITLE
Update table documentation to reflect actual implementation

### DIFF
--- a/doc/tables.md
+++ b/doc/tables.md
@@ -1,111 +1,91 @@
 # テーブル構成
 
 永続化するデータの構成について記載します。
+現在実装されているPrismaスキーマに基づくテーブル定義を以下に示します。
 
-## ユーザー関連テーブル
+## イベント関連テーブル
 
-### users（ユーザーテーブル）
+### events（イベントテーブル）
 | カラム名 | データ型 | NULL | キー | 説明 |
 |---------|---------|------|------|------|
-| id | SERIAL | NOT NULL | PK | ユーザーID |
-| username | VARCHAR(50) | NOT NULL | UK | ユーザー名 |
-| email | VARCHAR(255) | NOT NULL | UK | メールアドレス |
-| password_hash | VARCHAR(255) | NOT NULL | - | パスワードハッシュ |
-| role | ENUM('presenter', 'audience', 'admin') | NOT NULL | - | ユーザーロール |
-| created_at | TIMESTAMP | NOT NULL | - | 作成日時 |
-| updated_at | TIMESTAMP | NOT NULL | - | 更新日時 |
+| id | String (CUID) | NOT NULL | PK | イベント内部ID |
+| event_id | String | NOT NULL | UK | イベント識別子 |
+| title | String | NULL | - | イベントタイトル |
+| created_at | DateTime | NOT NULL | - | 作成日時 |
+| updated_at | DateTime | NOT NULL | - | 更新日時 |
 
-### sessions（セッションテーブル）
-| カラム名 | データ型 | NULL | キー | 説明 |
-|---------|---------|------|------|------|
-| id | VARCHAR(255) | NOT NULL | PK | セッションID |
-| user_id | INTEGER | NOT NULL | FK | ユーザーID |
-| expires_at | TIMESTAMP | NOT NULL | - | 有効期限 |
-| created_at | TIMESTAMP | NOT NULL | - | 作成日時 |
-
-## プレゼンテーション関連テーブル
-
-### presentations（プレゼンテーションテーブル）
-| カラム名 | データ型 | NULL | キー | 説明 |
-|---------|---------|------|------|------|
-| id | SERIAL | NOT NULL | PK | プレゼンテーションID |
-| title | VARCHAR(255) | NOT NULL | - | プレゼンテーションタイトル |
-| presenter_id | INTEGER | NOT NULL | FK | プレゼンターID |
-| status | ENUM('draft', 'active', 'completed') | NOT NULL | - | ステータス |
-| start_time | TIMESTAMP | NULL | - | 開始時刻 |
-| end_time | TIMESTAMP | NULL | - | 終了時刻 |
-| access_code | VARCHAR(10) | NOT NULL | UK | アクセスコード |
-| created_at | TIMESTAMP | NOT NULL | - | 作成日時 |
-| updated_at | TIMESTAMP | NOT NULL | - | 更新日時 |
+**リレーション:**
+- 1つのEventは複数のSurveyを持つ（1対多）
 
 ## アンケート関連テーブル
 
 ### surveys（アンケートテーブル）
 | カラム名 | データ型 | NULL | キー | 説明 |
 |---------|---------|------|------|------|
-| id | SERIAL | NOT NULL | PK | アンケートID |
-| presentation_id | INTEGER | NOT NULL | FK | プレゼンテーションID |
-| title | VARCHAR(255) | NOT NULL | - | アンケートタイトル |
-| description | TEXT | NULL | - | アンケート説明 |
-| type | ENUM('multiple_choice', 'single_choice', 'text', 'rating') | NOT NULL | - | アンケート種別 |
-| status | ENUM('draft', 'active', 'closed') | NOT NULL | - | ステータス |
-| display_order | INTEGER | NOT NULL | - | 表示順序 |
-| is_required | BOOLEAN | NOT NULL | - | 必須回答フラグ |
-| created_at | TIMESTAMP | NOT NULL | - | 作成日時 |
-| updated_at | TIMESTAMP | NOT NULL | - | 更新日時 |
+| id | String (CUID) | NOT NULL | PK | アンケート内部ID |
+| survey_id | String | NOT NULL | UK | アンケート識別子 |
+| event_id | String | NOT NULL | FK | イベント識別子 |
+| title | String | NOT NULL | - | アンケートタイトル |
+| question | String | NOT NULL | - | アンケート質問文 |
+| created_at | DateTime | NOT NULL | - | 作成日時 |
+| updated_at | DateTime | NOT NULL | - | 更新日時 |
+
+**リレーション:**
+- 1つのSurveyは1つのEventに属する（多対1）
+- 1つのSurveyは複数のSurveyOptionを持つ（1対多）
+- 1つのSurveyは複数のResponseを持つ（1対多）
 
 ### survey_options（アンケート選択肢テーブル）
 | カラム名 | データ型 | NULL | キー | 説明 |
 |---------|---------|------|------|------|
-| id | SERIAL | NOT NULL | PK | 選択肢ID |
-| survey_id | INTEGER | NOT NULL | FK | アンケートID |
-| option_text | VARCHAR(500) | NOT NULL | - | 選択肢テキスト |
-| display_order | INTEGER | NOT NULL | - | 表示順序 |
-| created_at | TIMESTAMP | NOT NULL | - | 作成日時 |
+| id | String (CUID) | NOT NULL | PK | 選択肢内部ID |
+| survey_id | String | NOT NULL | FK | アンケート識別子 |
+| text | String | NOT NULL | - | 選択肢テキスト |
+| order | Integer | NOT NULL | - | 表示順序 |
+
+**リレーション:**
+- 1つのSurveyOptionは1つのSurveyに属する（多対1）
+- 1つのSurveyOptionは複数のResponseを持つ（1対多）
 
 ### responses（回答テーブル）
 | カラム名 | データ型 | NULL | キー | 説明 |
 |---------|---------|------|------|------|
-| id | SERIAL | NOT NULL | PK | 回答ID |
-| survey_id | INTEGER | NOT NULL | FK | アンケートID |
-| user_id | INTEGER | NULL | FK | ユーザーID（匿名の場合はNULL） |
-| session_token | VARCHAR(255) | NULL | - | 匿名ユーザー識別トークン |
-| response_data | JSONB | NOT NULL | - | 回答データ（JSON形式） |
-| submitted_at | TIMESTAMP | NOT NULL | - | 回答日時 |
-| updated_at | TIMESTAMP | NOT NULL | - | 更新日時 |
+| id | String (CUID) | NOT NULL | PK | 回答内部ID |
+| survey_id | String | NOT NULL | FK | アンケート識別子 |
+| survey_option_id | String | NOT NULL | FK | 選択肢内部ID |
+| user_token | String | NULL | - | ユーザー識別トークン |
+| submitted_at | DateTime | NOT NULL | - | 回答日時 |
 
-## ログ関連テーブル
-
-### activity_logs（活動ログテーブル）
-| カラム名 | データ型 | NULL | キー | 説明 |
-|---------|---------|------|------|------|
-| id | SERIAL | NOT NULL | PK | ログID |
-| user_id | INTEGER | NULL | FK | ユーザーID |
-| action | VARCHAR(100) | NOT NULL | - | アクション |
-| resource_type | VARCHAR(50) | NOT NULL | - | リソース種別 |
-| resource_id | INTEGER | NULL | - | リソースID |
-| ip_address | INET | NULL | - | IPアドレス |
-| user_agent | TEXT | NULL | - | ユーザーエージェント |
-| created_at | TIMESTAMP | NOT NULL | - | 作成日時 |
-
-### system_logs（システムログテーブル）
-| カラム名 | データ型 | NULL | キー | 説明 |
-|---------|---------|------|------|------|
-| id | SERIAL | NOT NULL | PK | ログID |
-| level | ENUM('debug', 'info', 'warning', 'error', 'critical') | NOT NULL | - | ログレベル |
-| message | TEXT | NOT NULL | - | ログメッセージ |
-| context | JSONB | NULL | - | 追加コンテキスト |
-| created_at | TIMESTAMP | NOT NULL | - | 作成日時 |
+**リレーション:**
+- 1つのResponseは1つのSurveyに属する（多対1）
+- 1つのResponseは1つのSurveyOptionに属する（多対1）
 
 ## インデックス設計
 
-### パフォーマンス向上のためのインデックス
-- users.email（ユーザー検索用）
-- sessions.user_id（セッション管理用）
-- presentations.presenter_id（プレゼンター別検索用）
-- presentations.access_code（アクセスコード検索用）
-- surveys.presentation_id（プレゼンテーション別アンケート検索用）
+### 実装されているユニークインデックス
+- events.event_id（イベント識別子による検索用）
+- surveys.survey_id（アンケート識別子による検索用）
+
+### パフォーマンス向上のための推奨インデックス
+- surveys.event_id（イベント別アンケート検索用）
+- survey_options.survey_id（アンケート別選択肢検索用）
 - responses.survey_id（アンケート別回答検索用）
+- responses.survey_option_id（選択肢別回答検索用）
 - responses.submitted_at（時系列分析用）
-- activity_logs.user_id（ユーザー別ログ検索用）
-- activity_logs.created_at（時系列ログ検索用）
+- responses.user_token（ユーザー別回答検索用）
+
+## ER図
+
+```
+[Event] ||--o{ [Survey] : 1つのイベントに複数のアンケート
+[Survey] ||--o{ [SurveyOption] : 1つのアンケートに複数の選択肢
+[Survey] ||--o{ [Response] : 1つのアンケートに複数の回答
+[SurveyOption] ||--o{ [Response] : 1つの選択肢に複数の回答
+```
+
+## 備考
+
+- IDフィールドはすべてCUID（Collision-resistant Unique IDentifier）を使用
+- PostgreSQLデータベースを使用
+- リアルタイムアンケートシステムに特化したシンプルな構成
+- ユーザー認証は現在未実装（user_tokenによる簡易識別のみ）


### PR DESCRIPTION
テーブル設計ドキュメントを実装済みのPrismaスキーマに合わせて更新しました。

## 変更内容
- 実装されているテーブル構成（Event、Survey、SurveyOption、Response）に基づく更新
- テーブル間リレーションとER図の追加
- インデックス設計の推奨事項を追加
- 未実装テーブルの削除

Fixes #19

Generated with [Claude Code](https://claude.ai/code)