### PR TITLE
feat: update Node.js version to 24 in backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:24-alpine
 
 WORKDIR /app
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "MVP backend for real-time survey system",
   "main": "dist/index.js",
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "build": "tsc",
@@ -23,7 +26,7 @@
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/cors": "^2.8.17",
-    "@types/node": "^20.10.5",
+    "@types/node": "^22.0.0",
     "typescript": "^5.3.3",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0"


### PR DESCRIPTION
###概要

バックエンドのNode.jsバージョンを24に更新しました。

### 変更内容

1. **backend/Dockerfile**
   - `FROM node:18-alpine` → `FROM node:24-alpine`

2. **backend/package.json**
   - `engines` フィールドを追加: `"node": ">=24.0.0"`
   - `@types/node` を `^20.10.5` → `^22.0.0` に更新

### 関連Issue

Closes #25

---

Generated with [Claude Code](https://claude.ai/code)