### PR TITLE
fix: npm ci エラーを修正してバックエンドビルドを可能にする

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # 依存関係をインストール
-RUN npm ci --only=production && npm cache clean --force
+RUN npm install --only=production && npm cache clean --force
 
 # アプリケーションファイルをコピー
 COPY . .


### PR DESCRIPTION
npm ci エラーを修正してバックエンドのビルド問題を解決しました。

## 変更内容

- npm ci を npm install --only=production に変更
- package-lock.json が存在しなくても依存関係をインストール可能に
- Docker Compose起動時のビルドエラーを解決

Fixes #27

Generated with [Claude Code](https://claude.ai/code)