### PR TITLE
fix: バックエンドが起動しない問題を修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     volumes:
       - ./backend:/app
       - /app/node_modules
+      - /app/dist
     environment:
       - DATABASE_URL=postgresql://postgres:password@postgres:5432/realtime_survey
       - PORT=3001


### PR DESCRIPTION
Docker volumeマウントでdistディレクトリが上書きされる問題を解決するため、
/app/distをvolume除外リストに追加。これによりビルド時に生成された
dist/index.jsが保持され、バックエンドが正常に起動できるようになる。

Fixes #31

Generated with [Claude Code](https://claude.ai/code)