### PR TITLE
feat: Prismaを6.1.0にアップグレード

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -19,8 +19,8 @@
     "socket.io": "^4.7.5",
     "cors": "^2.8.5",
     "helmet": "^7.1.0",
-    "prisma": "^5.7.1",
-    "@prisma/client": "^5.7.1",
+    "prisma": "^6.1.0",
+    "@prisma/client": "^6.1.0",
     "crypto": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
OpenSSLのインストール場所変更に対応するため、Prismaのバージョンを5.7.1から6.1.0に更新しました。

Fixes #33

Generated with [Claude Code](https://claude.ai/code)