### PR TITLE
feat: イベントに紐づくアンケート作成画面を実装

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,8 +3,9 @@ import './App.css';
 import PresentationScreen from './components/PresentationScreen';
 import EventRegistration from './components/EventRegistration';
 import EventManagement from './components/EventManagement';
+import SurveyCreation from './components/SurveyCreation';
 
-type AppState = 'menu' | 'event-registration' | 'event-management' | 'presentation-setup' | 'presenting';
+type AppState = 'menu' | 'event-registration' | 'event-management' | 'survey-creation' | 'presentation-setup' | 'presenting';
 
 function App() {
   const [currentState, setCurrentState] = useState<AppState>('menu');
@@ -41,6 +42,19 @@ function App() {
     setEventTitle('');
   };
 
+  const handleCreateSurvey = () => {
+    setCurrentState('survey-creation');
+  };
+
+  const handleSurveyCreated = (surveyId: string, surveyTitle: string) => {
+    // アンケート作成後はイベント管理画面に戻る
+    setCurrentState('event-management');
+  };
+
+  const handleBackToEventManagement = () => {
+    setCurrentState('event-management');
+  };
+
   // 画面の状態管理
   switch (currentState) {
     case 'event-registration':
@@ -58,6 +72,17 @@ function App() {
           eventTitle={eventTitle}
           onBack={handleBackToEventRegistration}
           onStartPresentation={() => setCurrentState('presentation-setup')}
+          onCreateSurvey={handleCreateSurvey}
+        />
+      );
+
+    case 'survey-creation':
+      return (
+        <SurveyCreation
+          eventId={eventId}
+          eventTitle={eventTitle}
+          onBack={handleBackToEventManagement}
+          onSurveyCreated={handleSurveyCreated}
         />
       );
 

--- a/frontend/src/components/EventManagement.css
+++ b/frontend/src/components/EventManagement.css
@@ -148,6 +148,7 @@
   gap: 12px;
   margin-bottom: 30px;
   justify-content: center;
+  flex-wrap: wrap;
 }
 
 .secondary-button,
@@ -160,7 +161,8 @@
   font-weight: 500;
   cursor: pointer;
   transition: all 0.3s ease;
-  max-width: 200px;
+  max-width: 180px;
+  min-width: 150px;
 }
 
 .secondary-button {

--- a/frontend/src/components/EventManagement.tsx
+++ b/frontend/src/components/EventManagement.tsx
@@ -6,13 +6,15 @@ interface EventManagementProps {
   eventTitle: string;
   onBack: () => void;
   onStartPresentation: () => void;
+  onCreateSurvey: () => void;
 }
 
 const EventManagement: React.FC<EventManagementProps> = ({
   eventId,
   eventTitle,
   onBack,
-  onStartPresentation
+  onStartPresentation,
+  onCreateSurvey
 }) => {
   const [copiedEventId, setCopiedEventId] = useState<boolean>(false);
 
@@ -69,6 +71,12 @@ const EventManagement: React.FC<EventManagementProps> = ({
             className="secondary-button"
           >
             新しいイベントを作成
+          </button>
+          <button 
+            onClick={onCreateSurvey}
+            className="secondary-button"
+          >
+            アンケートを作成
           </button>
           <button 
             onClick={onStartPresentation}

--- a/frontend/src/components/SurveyCreation.css
+++ b/frontend/src/components/SurveyCreation.css
@@ -1,0 +1,303 @@
+.survey-creation {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+.survey-creation-container {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+  padding: 40px;
+  max-width: 600px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.survey-creation h1 {
+  text-align: center;
+  color: #333;
+  margin-bottom: 30px;
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.event-info {
+  background: #f8f9fa;
+  border: 1px solid #e9ecef;
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 30px;
+}
+
+.event-info p {
+  margin: 0 0 8px 0;
+  color: #495057;
+  font-size: 0.95rem;
+}
+
+.event-info p:last-child {
+  margin-bottom: 0;
+}
+
+.survey-form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-group label {
+  font-weight: 600;
+  color: #333;
+  font-size: 1rem;
+}
+
+.required {
+  color: #dc3545;
+  margin-left: 4px;
+}
+
+.form-group input,
+.form-group textarea {
+  padding: 12px 16px;
+  border: 2px solid #e9ecef;
+  border-radius: 8px;
+  font-size: 1rem;
+  transition: all 0.3s ease;
+  font-family: inherit;
+}
+
+.form-group input:focus,
+.form-group textarea:focus {
+  outline: none;
+  border-color: #667eea;
+  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+}
+
+.form-group input:disabled,
+.form-group textarea:disabled {
+  background-color: #f8f9fa;
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.form-group textarea {
+  resize: vertical;
+  min-height: 80px;
+}
+
+.options-container {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.option-input-group {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.option-number {
+  font-weight: 600;
+  color: #6c757d;
+  min-width: 24px;
+  font-size: 1rem;
+}
+
+.option-input-group input {
+  flex: 1;
+  margin: 0;
+}
+
+.remove-option-button {
+  background: #dc3545;
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 1.2rem;
+  line-height: 1;
+  transition: all 0.2s ease;
+  flex-shrink: 0;
+}
+
+.remove-option-button:hover:not(:disabled) {
+  background: #c82333;
+  transform: scale(1.1);
+}
+
+.remove-option-button:disabled {
+  background: #6c757d;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.add-option-button {
+  background: transparent;
+  color: #667eea;
+  border: 2px dashed #667eea;
+  border-radius: 8px;
+  padding: 12px 20px;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 500;
+  transition: all 0.2s ease;
+  margin-top: 8px;
+  align-self: flex-start;
+}
+
+.add-option-button:hover:not(:disabled) {
+  background: #667eea;
+  color: white;
+  border-style: solid;
+}
+
+.add-option-button:disabled {
+  color: #6c757d;
+  border-color: #6c757d;
+  cursor: not-allowed;
+}
+
+.error-message {
+  background: #f8d7da;
+  color: #721c24;
+  border: 1px solid #f5c6cb;
+  border-radius: 8px;
+  padding: 12px 16px;
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.form-actions {
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+  margin-top: 16px;
+}
+
+.back-button {
+  background: #6c757d;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  padding: 14px 28px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  flex: 1;
+}
+
+.back-button:hover:not(:disabled) {
+  background: #5a6268;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(108, 117, 125, 0.3);
+}
+
+.create-button {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  padding: 14px 28px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  flex: 2;
+}
+
+.create-button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(102, 126, 234, 0.4);
+}
+
+.create-button:disabled,
+.back-button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.tips {
+  margin-top: 30px;
+  padding: 20px;
+  background: #e7f3ff;
+  border: 1px solid #bee5eb;
+  border-radius: 8px;
+}
+
+.tips h3 {
+  margin: 0 0 12px 0;
+  color: #055160;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.tips ul {
+  margin: 0;
+  padding-left: 20px;
+  color: #055160;
+}
+
+.tips li {
+  margin-bottom: 6px;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.tips li:last-child {
+  margin-bottom: 0;
+}
+
+@media (max-width: 768px) {
+  .survey-creation {
+    padding: 10px;
+  }
+  
+  .survey-creation-container {
+    padding: 24px;
+    max-height: 95vh;
+  }
+  
+  .survey-creation h1 {
+    font-size: 1.6rem;
+    margin-bottom: 20px;
+  }
+  
+  .form-actions {
+    flex-direction: column;
+  }
+  
+  .back-button,
+  .create-button {
+    flex: none;
+  }
+  
+  .option-input-group {
+    gap: 8px;
+  }
+  
+  .option-number {
+    min-width: 20px;
+    font-size: 0.9rem;
+  }
+}


### PR DESCRIPTION
Closes #35

This PR implements a survey creation screen linked to events.

## Changes
- Created SurveyCreation component with form validation
- Added dynamic option management (2-10 options)
- Updated EventManagement with survey creation button
- Enhanced App.tsx state management for navigation
- Updated documentation in doc/screens.md

## Features
- Survey title and question input
- Dynamic option addition/deletion
- Form validation and error handling
- Event association functionality
- Responsive design

Generated with [Claude Code](https://claude.ai/code)