### PR TITLE
feat: イベントIDからアンケート一覧を取得するAPIを追加

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -88,6 +88,11 @@ Content-Type: application/json
 }
 ```
 
+#### イベントのアンケート一覧取得
+```
+GET /api/surveys/events/:eventId/surveys
+```
+
 #### アンケート取得
 ```
 GET /api/surveys/events/:eventId/surveys/:surveyId


### PR DESCRIPTION
イベントIDを受け取り、アンケートIDと質問を返却するAPIエンドポイントを追加しました。

## 変更内容
- `GET /api/surveys/events/:eventId/surveys` エンドポイントを実装
- イベントに紐づく全アンケートの詳細を返却
- イベント存在確認とエラーハンドリングを実装
- backend/README.mdにAPIドキュメントを追加

Closes #49

Generated with [Claude Code](https://claude.ai/code)