### PR TITLE
fix: Google Cloud SQL Database Instanceでのlabels設定エラーを修正

### DIFF
--- a/infra/terraform/database.tf
+++ b/infra/terraform/database.tf
@@ -39,9 +39,10 @@ resource "google_sql_database_instance" "postgres" {
 
     # コスト最適化の設定
     pricing_plan = "PER_USE"                      # 使用量ベース課金
+    
+    # ラベル設定（settingsブロック内でuser_labelsを使用）
+    user_labels = local.labels
   }
-
-  labels = local.labels
 }
 
 # データベース作成


### PR DESCRIPTION
database.tfでgoogle_sql_database_instanceリソースに直接labelsを設定していたが、このリソースタイプではlabels引数はサポートされていない。正しくsettingsブロック内でuser_labelsを使用するように修正。

Fixes #61

🤖 Generated with [Claude Code](https://claude.ai/code)