### PR TITLE
fix: remove unsupported labels argument from google_compute_network

### DIFF
--- a/infra/terraform/network.tf
+++ b/infra/terraform/network.tf
@@ -2,8 +2,6 @@
 resource "google_compute_network" "vpc" {
   name                    = "${local.app_name}-vpc"
   auto_create_subnetworks = false
-  
-  labels = local.labels
 }
 
 # サブネット作成


### PR DESCRIPTION
Fixes deployment error in issue #75

Google Cloud Provider 5.x does not support the `labels` argument for `google_compute_network` resources. This was causing the deploy.sh script to fail with "Unsupported argument" error.

Changes:
- Removed `labels = local.labels` from the VPC network resource definition
- Other resources continue to use labels as expected

Generated with [Claude Code](https://claude.ai/code)