### PR TITLE
fix: GCPデプロイ時に必要なAPIの有効化を追加

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -77,6 +77,8 @@ gcloud services enable run.googleapis.com
 gcloud services enable sql-component.googleapis.com
 gcloud services enable sqladmin.googleapis.com
 gcloud services enable artifactregistry.googleapis.com
+gcloud services enable vpcaccess.googleapis.com
+gcloud services enable servicenetworking.googleapis.com
 ```
 
 #### 3.2 Terraformでインフラ構築
@@ -174,6 +176,11 @@ gcloud run jobs delete migration-job --region=asia-northeast1 --quiet
 2. **APIが有効化されていない**
    ```bash
    gcloud services enable [API-NAME]
+   ```
+   特に、VPCアクセスコネクタを使用する場合は以下が必要：
+   ```bash
+   gcloud services enable vpcaccess.googleapis.com
+   gcloud services enable servicenetworking.googleapis.com
    ```
 
 3. **Docker認証エラー**

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -48,6 +48,8 @@ gcloud services enable run.googleapis.com
 gcloud services enable sql-component.googleapis.com
 gcloud services enable sqladmin.googleapis.com
 gcloud services enable artifactregistry.googleapis.com
+gcloud services enable vpcaccess.googleapis.com
+gcloud services enable servicenetworking.googleapis.com
 
 # Docker認証設定
 echo -e "${YELLOW}Artifact Registryの認証を設定中...${NC}"


### PR DESCRIPTION
Serverless VPC Access API (vpcaccess.googleapis.com) と
Service Networking API (servicenetworking.googleapis.com) の有効化を
deploy.shスクリプトに追加。

これにより、VPCアクセスコネクタ作成時のAPIエラーを解決。

Fixes #77

Generated with [Claude Code](https://claude.ai/code)