### PR TITLE
fix: データベースホストをprivate_ip_addressに修正してマイグレーション失敗を解決

### DIFF
--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -20,7 +20,7 @@ output "backend_url" {
 
 output "database_host" {
   description = "データベースのホスト"
-  value       = google_sql_database_instance.postgres.public_ip_address
+  value       = google_sql_database_instance.postgres.private_ip_address
 }
 
 output "database_name" {


### PR DESCRIPTION
マイグレーション失敗の原因を特定し、修正しました。

## 変更内容
- `infra/terraform/outputs.tf`の`database_host`を`public_ip_address`から`private_ip_address`に変更
- パブリックIPが無効化されている環境でのプライベートネットワークアクセスに対応

Fixes #79

Generated with [Claude Code](https://claude.ai/code)