### PR TITLE
fix: migration-jobにVPC接続設定を追加

### DIFF
--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -114,16 +114,20 @@ DB_USER=$(cd terraform && terraform output -raw database_user)
 DB_PASSWORD=$(cd terraform && terraform output -raw database_password)
 DB_HOST=$(cd terraform && terraform output -raw database_host)
 DB_NAME=$(cd terraform && terraform output -raw database_name)
+VPC_CONNECTOR=$(cd terraform && terraform output -raw vpc_connector_name)
 
 echo "データベース接続情報:"
 echo "  ユーザー: $DB_USER"
 echo "  ホスト: $DB_HOST" 
 echo "  データベース名: $DB_NAME"
+echo "  VPCコネクタ: $VPC_CONNECTOR"
 
 # マイグレーション用のCloud Runジョブを一時的に作成して実行
 gcloud run jobs create migration-job \
     --image=${DOCKER_REPO}/backend:latest \
     --region=$REGION \
+    --vpc-connector=$VPC_CONNECTOR \
+    --vpc-egress=private-ranges-only \
     --set-env-vars="DATABASE_URL=postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:5432/${DB_NAME}" \
     --command="npx" \
     --args="prisma,migrate,deploy"

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -48,3 +48,8 @@ output "docker_repo_url" {
   description = "DockerイメージのリポジトリURL"
   value       = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.repo.repository_id}"
 }
+
+output "vpc_connector_name" {
+  description = "VPCコネクタ名"
+  value       = google_vpc_access_connector.connector.name
+}


### PR DESCRIPTION
migration-jobがrealtime-survey-vpcに接続できない問題を修正

## 変更内容
- outputs.tfにvpc_connector_nameを追加
- deploy.shでマイグレーションジョブ作成時に--vpc-connectorと--vpc-egressオプションを追加

## 修正する問題
Fixes #81

Generated with [Claude Code](https://claude.ai/code)