### PR TITLE
fix: デプロイ時にREACT_APP_BACKEND_URL環境変数を正しく設定

### DIFF
--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -103,8 +103,10 @@ gcloud run services update realtime-survey-backend \
     --image=${DOCKER_REPO}/backend:latest \
     --region=$REGION
 
+# フロントエンドにバックエンドURLを環境変数として設定
 gcloud run services update realtime-survey-frontend \
     --image=${DOCKER_REPO}/frontend:latest \
+    --set-env-vars="REACT_APP_BACKEND_URL=${BACKEND_URL}" \
     --region=$REGION
 
 # データベースマイグレーション


### PR DESCRIPTION
Issue #85で報告された、デプロイ時にREACT_APP_BACKEND_URL環境変数が更新されない問題を修正しました。

## 修正内容
- フロントエンドのCloud Runサービス更新時に--set-env-varsオプションを追加
- TerraformのBACKEND_URL出力をREACT_APP_BACKEND_URL環境変数として設定
- これによりentrypoint.shでバックエンドURLが正しく注入される

Fixes #85

Generated with [Claude Code](https://claude.ai/code)