### PR TITLE
fix: プレゼンテーション開始ボタンでプレゼンテーション画面に直接遷移するよう修正

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -86,7 +86,7 @@ const PresenterApp: React.FC = () => {
           eventId={eventId}
           eventTitle={eventTitle}
           onBack={handleBackToEventRegistration}
-          onStartPresentation={() => setCurrentState('presentation-setup')}
+          onStartPresentation={() => setCurrentState('presenting')}
           onCreateSurvey={handleCreateSurvey}
           onStartPresentationWithUrl={handleStartPresentationWithUrl}
         />

--- a/frontend/src/components/PresentationScreen.css
+++ b/frontend/src/components/PresentationScreen.css
@@ -369,3 +369,37 @@
     align-self: flex-end;
   }
 }
+
+/* プレゼンテーションプレースホルダー */
+.presentation-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+}
+
+.placeholder-content {
+  text-align: center;
+  padding: 40px;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+}
+
+.placeholder-content h2 {
+  margin: 0 0 20px 0;
+  font-size: 2.5em;
+  font-weight: 300;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+.placeholder-content p {
+  margin: 10px 0;
+  font-size: 1.2em;
+  opacity: 0.9;
+  line-height: 1.5;
+}

--- a/frontend/src/components/PresentationScreen.tsx
+++ b/frontend/src/components/PresentationScreen.tsx
@@ -229,13 +229,23 @@ const PresentationScreen: React.FC<PresentationScreenProps> = ({
       className={`presentation-container ${isFullscreen ? 'fullscreen' : ''}`}
     >
       {/* Google Slides埋め込み */}
-      <iframe
-        src={getEmbedUrl(presentationUrl)}
-        className="presentation-iframe"
-        frameBorder="0"
-        allowFullScreen
-        title="Google Slides Presentation"
-      />
+      {presentationUrl ? (
+        <iframe
+          src={getEmbedUrl(presentationUrl)}
+          className="presentation-iframe"
+          frameBorder="0"
+          allowFullScreen
+          title="Google Slides Presentation"
+        />
+      ) : (
+        <div className="presentation-placeholder">
+          <div className="placeholder-content">
+            <h2>プレゼンテーション画面</h2>
+            <p>スライドURLが設定されていません</p>
+            <p>設定画面に戻ってURLを入力してください</p>
+          </div>
+        </div>
+      )}
       
 
       {/* コントロールパネル */}


### PR DESCRIPTION
Fixes #95

イベント管理画面の「プレゼンテーション開始」ボタンが機能しない問題を修正

**修正内容:**
- EventManagementコンポーネントの「プレゼンテーション画面へ」ボタンを直接presenting状態に遷移するよう変更
- PresentationScreenコンポーネントでURL未指定時のプレースホルダー表示を追加
- プレースホルダー用のCSSスタイルを追加

Generated with [Claude Code](https://claude.ai/code)