### PR TITLE
fix: イベント管理画面の「プレゼンテーション開始」ボタンの問題を修正

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -199,6 +199,8 @@ const PresenterApp: React.FC = () => {
 // パスパラメータ対応のイベント管理画面コンポーネント
 const EventManagementRoute: React.FC = () => {
   const { eventId } = useParams<{ eventId: string }>();
+  const [isPresenting, setIsPresenting] = useState<boolean>(false);
+  const [presentationUrl, setPresentationUrl] = useState<string>('');
   
   if (!eventId) {
     return (
@@ -211,15 +213,39 @@ const EventManagementRoute: React.FC = () => {
     );
   }
 
-  // URL直接アクセス時は簡単なプレゼンテーション遷移ハンドラーのみ提供
+  // URL直接アクセス時のプレゼンテーション遷移ハンドラー
   const handlePresentationStart = () => {
     window.location.href = '/';
   };
+
+  // URLを指定してプレゼンテーションを開始
+  const handleStartPresentationWithUrl = (url: string) => {
+    setPresentationUrl(url);
+    setIsPresenting(true);
+  };
+
+  // プレゼンテーション終了
+  const handleExitPresentation = () => {
+    setIsPresenting(false);
+    setPresentationUrl('');
+  };
+
+  // プレゼンテーション画面を表示
+  if (isPresenting && presentationUrl) {
+    return (
+      <PresentationScreen 
+        presentationUrl={presentationUrl}
+        eventId={eventId}
+        onExit={handleExitPresentation}
+      />
+    );
+  }
 
   return (
     <EventManagement 
       eventId={eventId} 
       onStartPresentation={handlePresentationStart}
+      onStartPresentationWithUrl={handleStartPresentationWithUrl}
     />
   );
 };


### PR DESCRIPTION
## 修正内容

イベント管理画面で「プレゼンテーション開始」ボタンが機能しないバグを修正しました。

- EventManagementRouteコンポーネントにonStartPresentationWithUrlハンドラーを追加
- URL直接アクセス時でもプレゼンテーション画面への遷移が可能に
- プレゼンテーション状態管理とURL保存機能を実装

## 関連イシュー

Fixes #97

Generated with [Claude Code](https://claude.ai/code)